### PR TITLE
Disable Post Revisions using the correct action

### DIFF
--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -186,7 +186,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 			$siblings = new WP_Query( $siblings_query ); // fetch all the siblings (relative ordering)
 
 			// don't waste overhead of revisions on a menu order change (especially since they can't *all* be rolled back at once)
-			remove_action( 'pre_post_update', 'wp_save_post_revision' );
+			remove_action( 'post_updated', 'wp_save_post_revision' );
 
 			foreach ( $siblings->posts as $sibling ) :
 


### PR DESCRIPTION
WordPress adds `wp_save_post_revision` to the `post_updated` action and not `pre_post_update`, as can be seen here: https://github.com/WordPress/WordPress/blob/56c162fbc9867f923862f64f1b4570d885f1ff03/wp-includes/default-filters.php#L342