### PR TITLE
Fix "tested up to" badge placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Simple Page Ordering
 
-> Order your pages and other hierarchical post types with simple drag and drop right from the standard page list. 
+> Order your pages and other hierarchical post types with simple drag and drop right from the standard page list.
+
 ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.2%20tested-success.svg)
 
 Order your pages, hierarchical custom post types, or custom post types with "page-attributes" with simple drag and drop right from the built in page list. 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

The "tested up to" WordPress badge was appearing in the plugin description quote, so this moves it onto the line below.

### Alternate Designs

n/a

### Benefits

Ensures visual layout of readme matches 10up open source standard.

### Possible Drawbacks

none identified

### Verification Process

Checked visually via GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/simple-page-ordering/blob/develop/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

none
