### PR TITLE
Fix: Avoid post__not_in

### DIFF
--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -186,7 +186,6 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 					'menu_order' => 'ASC',
 					'title'      => 'ASC',
 				),
-				'post__not_in'           => $excluded,
 				'update_post_term_cache' => false,
 				'update_post_meta_cache' => false,
 				'suppress_filters'       => true,
@@ -205,6 +204,11 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 
 				// don't handle the actual post
 				if ( $sibling->ID === $post->ID ) {
+					continue;
+				}
+
+
+				if ( ! in_array( $post->ID, $excluded, true ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Remove the usage of `post__not_in` and using php to filter excluded posts instead.
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs
n/a
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits
See: https://10up.github.io/Engineering-Best-Practices/php/#performance
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
There may be a very edge case when 
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
Closes #3 
<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
Changed: Remove `post__not_in` and use php to filter excluded post.