### PR TITLE
Fix: enqueue script and style using the correct version

### DIFF
--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -14,6 +14,8 @@
 
 if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 
+	define( 'SPO_VERSION', '2.3.4' );
+
 	class Simple_Page_Ordering {
 
 		/**
@@ -91,7 +93,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 			$screen  = get_current_screen();
 			if ( ( is_string( $orderby ) && 0 === strpos( $orderby, 'menu_order' ) ) || ( isset( $orderby['menu_order'] ) && 'ASC' === $orderby['menu_order'] ) ) {
 				$script_name = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '/assets/js/src/simple-page-ordering.js' : '/assets/js/simple-page-ordering.min.js';
-				wp_enqueue_script( 'simple-page-ordering', plugins_url( $script_name, __FILE__ ), array( 'jquery-ui-sortable' ), '2.1', true );
+				wp_enqueue_script( 'simple-page-ordering', plugins_url( $script_name, __FILE__ ), array( 'jquery-ui-sortable' ), SPO_VERSION, true );
 				wp_localize_script(
 					'simple-page-ordering',
 					'simple_page_ordering_localized_data',
@@ -100,7 +102,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 						'screen_id' => (string) $screen->id,
 					)
 				);
-				wp_enqueue_style( 'simple-page-ordering', plugins_url( '/assets/css/simple-page-ordering.css', __FILE__ ) );
+				wp_enqueue_style( 'simple-page-ordering', plugins_url( '/assets/css/simple-page-ordering.css', __FILE__ ), array(), SPO_VERSION );
 			}
 		}
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
- Define a constant (`SPO_VERSION`) holding the plugin version.
- Enqueue scripts and style using the correct plugin version.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs
n/a
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits
Prevent cache issue after updating our plugin to newer versions.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
n/a
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Check the page source to see scripts and styles have the correct version.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
