### PR TITLE
Fix condition in rest_page_ordering method

### DIFF
--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -465,7 +465,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 			$excluded = empty( $request->get_param( 'excluded' ) ) ? array( $request->get_param( 'id' ) ) : array_filter( (array) json_decode( $request->get_param( 'excluded' ) ), 'intval' );
 
 			// Check and make sure we have what we need.
-			if ( false === $post_id ) || ( false === $previd && false === $nextid ) ) {
+			if ( false === $post_id || ( false === $previd && false === $nextid ) ) {
 				return new WP_Error( __( 'Missing mandatory parameters.', 'simple-page-ordering' ) );
 			}
 

--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -464,8 +464,8 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 			$start    = empty( $request->get_param( 'start' ) ) ? 1 : (int) $request->get_param( 'start' );
 			$excluded = empty( $request->get_param( 'excluded' ) ) ? array( $request->get_param( 'id' ) ) : array_filter( (array) json_decode( $request->get_param( 'excluded' ) ), 'intval' );
 
-			// check and make sure we have what we need
-			if ( empty( $post_id ) || ( ! isset( $previd ) && ! isset( $nextid ) ) ) {
+			// Check and make sure we have what we need.
+			if ( false === $post_id ) || ( false === $previd && false === $nextid ) ) {
 				return new WP_Error( __( 'Missing mandatory parameters.', 'simple-page-ordering' ) );
 			}
 


### PR DESCRIPTION
### Description of the Change

e.g. `$previd` could never be `null`

### Verification Process

Manually by me.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Fixed - Condition in rest_page_ordering

Props @szepeviktor 