### PR TITLE
Only check for page-attributes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,9 @@ Generic posts are not displayed by menu order - they're displayed by chronology.
 
 ### Can I make my custom post type take advantage of this plug-in?
 
-Yep. There are two ways to turn on support for Simple Page Ordering.
+Ideally, when you register the post type, include `page-attributes` feature in the support list. This will add a `Sort by Order` option to the filter links above the drop downs. Once you sort by order, you can drag and drop the content.
 
-Ideally, when you register the post type, set `hierarchical` to `true` - hierarchical post types natively order by menu order.
-
-Alternatively, when you define the features the post type supports, include `page-attributes`. This will add a `Sort by Order` option to the filter links above the drop downs. Once you sort by order, you can drag and drop the content.
+`'supports' => array( 'title', 'editor', 'page-attributes' ),`
 
 Finally, you can take advantage of the `simple_page_ordering_is_sortable` filter, which passes the result of the default check and the post type name, to override default behavior.
 

--- a/readme.txt
+++ b/readme.txt
@@ -42,13 +42,9 @@ Generic posts are not displayed by menu order - they're displayed by chronology.
 
 = Can I make my custom post type take advantage of this plug-in? =
 
-Yep. There are two ways to turn on support for Simple Page Ordering.
+Ideally, when you register the post type, include `page-attributes` feature in the support list. This will add a `Sort by Order` option to the filter links above the drop downs. Once you sort by order, you can drag and drop the content.
 
-Ideally, when you register the post type, set `hierarchical` to `true` - hierarchical post types natively order by menu order.
-
-Alternatively, when you define the features the post type supports, include `page-attributes`. This will add a `Sort by Order` option to the filter links above the drop downs. Once you sort by order, you can drag and drop the content.
-
-Finally, you can take advantage of the `simple_page_ordering_is_sortable` filter, which passes the result of the default check and the post type name, to override default behavior.
+`'supports' => array( 'title', 'editor', 'page-attributes' ),`
 
 = I want my non-hierarchical post type to be sortable. Help! =
 

--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -66,6 +66,17 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 		}
 
 		/**
+		 * Determine whether given post type is sortable or not.
+		 *
+		 * @param string $post_type Post type to check.
+		 *
+		 * @return boolean
+		 */
+		private static function is_post_type_sortable( $post_type = 'post' ) {
+			return apply_filters( 'simple_page_ordering_is_sortable', post_type_supports( $post_type, 'page-attributes' ), $post_type );
+		}
+
+		/**
 		 * Load up page ordering scripts for the edit screen
 		 */
 		public static function load_edit_screen() {
@@ -73,8 +84,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 			$post_type = $screen->post_type;
 
 			// is post type sortable?
-			$sortable = ( post_type_supports( $post_type, 'page-attributes' ) || is_post_type_hierarchical( $post_type ) );        // check permission
-			$sortable = apply_filters( 'simple_page_ordering_is_sortable', $sortable, $post_type );
+			$sortable = self::is_post_type_sortable( $post_type );
 			if ( ! $sortable ) {
 				return;
 			}
@@ -385,7 +395,8 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 		public static function sort_by_order_link( $views ) {
 			$class        = ( get_query_var( 'orderby' ) === 'menu_order title' ) ? 'current' : '';
 			$query_string = remove_query_arg( array( 'orderby', 'order' ) );
-			if ( ! is_post_type_hierarchical( get_post_type() ) ) {
+			$sortable     = self::is_post_type_sortable( get_post_type() );
+			if ( $sortable ) {
 				$query_string = add_query_arg( 'orderby', 'menu_order title', $query_string );
 				$query_string = add_query_arg( 'order', 'asc', $query_string );
 			}


### PR DESCRIPTION
### Description of the Change
Enable ordering support only when the post type supports `page-attributes`.

Closes #96 

### How to test the Change

1. Disable this plugin
2. Enable a hierarchical CPT without `page-attributes` support. I've created a [gist with a mini plugin](https://gist.github.com/peterwilsoncc/afe5d3c04b137e2d8bcfcde97b8cf6fa).
3. Create 20 CPT posts via wp-cli: `wp post generate --count=20 --post_type=pwcc_test_type`
4. Edit one of the CPTs in the WP Dashboard
5. Observe you can't modify the menu position via the page attributes setting
6. Enable this plugin
7. Visit the CPTs post list table
8. Observe you can't modify the menu position via drag and drop
9. Add `page-attributes` support in the code
10. Visit the CPTs post list table
11. Observe you can modify the menu position via drag and drop

### Changelog Entry
Fix - Disable reordering for CPTs without support for page attributes


### Credits
Props @dhanendran 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
