### PR TITLE
Add back the check for hierarchical post types, instead of just relying on `page-attributes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Yep. When you register the post type, include the `page-attributes` feature in t
 
 `'supports' => array( 'title', 'editor', 'page-attributes' ),`
 
+Alternatively, when you register the post type, set `hierarchical` to `true` - hierarchical post types natively order by menu order.
+
 You can also take advantage of the `simple_page_ordering_is_sortable` filter, which passes the result of the default check and the post type name, to override default behavior.
 
 ### I want my non-hierarchical post type to be sortable. Help!

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ Where 5 is the number of items to batch on each request (the default is 50). Not
 
 This feature is already built into WordPress natively, but a bit tucked away. If you pull down the "Screen Options" tab up top (on the list of post objects) there's a field where you can specify the number of items to show per page. I decided it was not a very good practice to duplicate this.
 
-### How can I exclude certain custom post types?
+### How can I modify sortable post types?
 
-Custom post types can be excluded by using the `simple_page_ordering_is_sortable` filter.
+Post types can be included or excluded by using the `simple_page_ordering_is_sortable` filter.
 
-For example, with `excluded_post_type` as the custom post type ID, add the following snippet in the theme function file or custom plugin:
+For example, to exclude the `excluded_post_type` custom post type, add the following snippet in the theme function file or custom plugin:
 
 ```
 add_filter( 'simple_page_ordering_is_sortable', function( $sortable, $post_type ) {
@@ -74,6 +74,17 @@ add_filter( 'simple_page_ordering_is_sortable', function( $sortable, $post_type 
 		return false;
 	}
 	return $sortable;
+}, 10, 2 );
+```
+
+To include the `include_post_type` custom post type, add the following snippet in the theme function file or custom plugin:
+
+```
+add_filter( 'simple_page_ordering_is_sortable', function( $sortable, $post_type ) {
+    if ( 'include_post_type' === $post_type ) {
+        return true;
+    }
+    return $sortable;
 }, 10, 2 );
 ```
 

--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,8 @@ Yep. When you register the post type, include the `page-attributes` feature in t
 
 `'supports' => array( 'title', 'editor', 'page-attributes' ),`
 
+Alternatively, when you register the post type, set `hierarchical` to `true` - hierarchical post types natively order by menu order.
+
 You can also take advantage of the `simple_page_ordering_is_sortable` filter, which passes the result of the default check and the post type name, to override default behavior.
 
 = I want my non-hierarchical post type to be sortable. Help! =

--- a/readme.txt
+++ b/readme.txt
@@ -72,11 +72,11 @@ Where 5 is the number of items to batch on each request (the default is 50). Not
 
 This feature is already built into WordPress natively, but a bit tucked away. If you pull down the "Screen Options" tab up top (on the list of post objects) there's a field where you can specify the number of items to show per page. I decided it was not a very good practice to duplicate this.
 
-= How can I exclude certain custom post types? =
+= How can I modify sortable post types? =
 
-Custom post types can be excluded by using the `simple_page_ordering_is_sortable` filter.
+Post types can be included or excluded by using the `simple_page_ordering_is_sortable` filter.
 
-For example, with `excluded_post_type` as the custom post type ID, add the following snippet in the theme function file or custom plugin:
+For example, to exclude the `excluded_post_type` custom post type, add the following snippet in the theme function file or custom plugin:
 
 `
 add_filter( 'simple_page_ordering_is_sortable', function( $sortable, $post_type ) {
@@ -86,6 +86,17 @@ add_filter( 'simple_page_ordering_is_sortable', function( $sortable, $post_type 
 	return $sortable;
 }, 10, 2 );
 `
+
+To include the `include_post_type` custom post type, add the following snippet in the theme function file or custom plugin:
+
+```
+add_filter( 'simple_page_ordering_is_sortable', function( $sortable, $post_type ) {
+	if ( 'include_post_type' === $post_type ) {
+		return true;
+	}
+	return $sortable;
+}, 10, 2 );
+```
 
 = Can I use REST to order posts? =
 

--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -73,7 +73,15 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 		 * @return boolean
 		 */
 		private static function is_post_type_sortable( $post_type = 'post' ) {
-			return apply_filters( 'simple_page_ordering_is_sortable', post_type_supports( $post_type, 'page-attributes' ), $post_type );
+			$sortable = ( post_type_supports( $post_type, 'page-attributes' ) || is_post_type_hierarchical( $post_type ) );
+
+			/**
+			 * Change default ordering support for a post type.
+			 *
+			 * @param boolean $sortable Whether this post type is sortable or not.
+			 * @param string  $post_type The post type being checked.
+			 */
+			return apply_filters( 'simple_page_ordering_is_sortable', $sortable, $post_type );
 		}
 
 		/**
@@ -416,8 +424,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 		public static function sort_by_order_link( $views ) {
 			$class        = ( get_query_var( 'orderby' ) === 'menu_order title' ) ? 'current' : '';
 			$query_string = remove_query_arg( array( 'orderby', 'order' ) );
-			$sortable     = self::is_post_type_sortable( get_post_type() );
-			if ( $sortable ) {
+			if ( ! is_post_type_hierarchical( get_post_type() ) ) {
 				$query_string = add_query_arg( 'orderby', 'menu_order title', $query_string );
 				$query_string = add_query_arg( 'order', 'asc', $query_string );
 			}

--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -78,6 +78,8 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 			/**
 			 * Change default ordering support for a post type.
 			 *
+			 * @since 2.2.4
+			 *
 			 * @param boolean $sortable Whether this post type is sortable or not.
 			 * @param string  $post_type The post type being checked.
 			 */


### PR DESCRIPTION
### Description of the Change

In #103, we changed our sortable check to only rely on if a post type supports `page-attributes`. This broke sorting for sites that use post types that are hierarchical but don't have that attribute set. While it may better align with how core is set up to only look at `page-attributes`, it seems best to revert that change so we're not breaking functionality on sites that rely on the old behavior.

This isn't a complete revert of the changes introduced in #103 but does bring back the missing functionality.

### How to test the Change

1. Create a post type that has `page-attributes` set
2. Add content to this post type
3. Ensure you can sort this content and it reflects properly on the front-end
4. Create a post type that doesn't have `page-attributes` set but is set as hierarchical
5. Run through the same test steps and ensure things work

### Changelog Entry

> Changed - Allow hierarchical post types that don't have `page-attributes` set to be sorted.

### Credits

Props @dkotter

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
