### PR TITLE
Add a new GitHub Action to build a release zip

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -1,0 +1,61 @@
+name: Build release zip
+
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    name: Build release zip
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+      - uses: actions/checkout@v3
+
+      - name: Cache vendor
+        id: cache-composer
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-vendor
+        with:
+          path: |
+            vendor
+            ~/.composer/cache
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Setup node version and npm cache
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci --no-optional
+
+      - name: Install Composer dependencies
+        if: steps.cache-vendor.outputs.cache-hit != 'true'
+        run: composer install --no-dev
+
+      - name: Build plugin
+        run: npm run build
+
+      - name: Generate ZIP file
+        run: bash bin/build-zip.sh
+
+      - name: Unzip the file (prevents double zip problem)
+        run: unzip ${{ github.event.repository.name }}.zip -d zipfile
+
+      - name: Upload the ZIP file as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.event.repository.name }}
+          path: zipfile
+          retention-days: 5

--- a/bin/build-zip.sh
+++ b/bin/build-zip.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+# Note that this does not use pipefail
+# because if the grep later doesn't match any deleted files,
+# which is likely the majority case,
+# it does not exit with a 0, and we only care about the final exit.
+set -eo
+
+# Allow some ENV variables to be customized
+if [[ -z "$SLUG" ]]; then
+	SLUG=${GITHUB_REPOSITORY#*/}
+fi
+echo "ℹ︎ SLUG is $SLUG"
+
+if [[ -z "$BUILD_DIR" ]] || [[ $BUILD_DIR == "./" ]]; then
+	BUILD_DIR=false
+elif [[ $BUILD_DIR == ./* ]]; then
+	BUILD_DIR=${BUILD_DIR:2}
+fi
+
+if [[ "$BUILD_DIR" != false ]]; then
+	if [[ $BUILD_DIR != /* ]]; then
+		BUILD_DIR="${GITHUB_WORKSPACE%/}/${BUILD_DIR%/}"
+	fi
+	echo "ℹ︎ BUILD_DIR is $BUILD_DIR"
+fi
+
+SVN_URL="https://plugins.svn.wordpress.org/${SLUG}/"
+SVN_DIR="${HOME}/svn-${SLUG}"
+
+# Checkout just trunk for efficiency
+# Tagging will be handled on the SVN level
+echo "➤ Checking out .org repository..."
+svn checkout --depth immediates "$SVN_URL" "$SVN_DIR"
+cd "$SVN_DIR"
+svn update --set-depth infinity trunk
+
+if [[ "$BUILD_DIR" = false ]]; then
+	echo "➤ Copying files..."
+	if [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
+		echo "ℹ︎ Using .distignore"
+		# Copy from current branch to /trunk, excluding dotorg assets
+		# The --delete flag will delete anything in destination that no longer exists in source
+		rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete --delete-excluded
+	else
+		echo "ℹ︎ Using .gitattributes"
+
+		cd "$GITHUB_WORKSPACE"
+
+		# "Export" a cleaned copy to a temp directory
+		TMP_DIR="${HOME}/archivetmp"
+		mkdir "$TMP_DIR"
+
+		git config --global user.email "10upbot+github@10up.com"
+		git config --global user.name "10upbot on GitHub"
+
+		# If there's no .gitattributes file, write a default one into place
+		if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
+			cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL
+			/.gitattributes export-ignore
+			/.gitignore export-ignore
+			/.github export-ignore
+			EOL
+
+			# Ensure we are in the $GITHUB_WORKSPACE directory, just in case
+			# The .gitattributes file has to be committed to be used
+			# Just don't push it to the origin repo :)
+			git add .gitattributes && git commit -m "Add .gitattributes file"
+		fi
+
+		# This will exclude everything in the .gitattributes file with the export-ignore flag
+		git archive HEAD | tar x --directory="$TMP_DIR"
+
+		cd "$SVN_DIR"
+
+		# Copy from clean copy to /trunk, excluding dotorg assets
+		# The --delete flag will delete anything in destination that no longer exists in source
+		rsync -rc "$TMP_DIR/" trunk/ --delete --delete-excluded
+	fi
+else
+	echo "ℹ︎ Copying files from build directory..."
+	rsync -rc "$BUILD_DIR/" trunk/ --delete --delete-excluded
+fi
+
+echo "➤ Generating zip file..."
+cd "$SVN_DIR/trunk" || exit
+zip -r "${GITHUB_WORKSPACE}/${SLUG}.zip" .
+echo "zip-path=${GITHUB_WORKSPACE}/${SLUG}.zip" >> "${GITHUB_OUTPUT}"
+echo "✓ Zip file generated!"


### PR DESCRIPTION
### Description of the Change

Historically when we release a new plugin version, we checkout the `trunk` branch locally and test from that. This branch may not be a 100% accurate representation on what actually ends up getting deployed to WordPress.org, leading to potential missed issues in testing.

This PR adds a new GitHub Action that can be triggered on any branch that will build out a release zip and upload that as an artifact. This artifact should be exactly* the same as what will eventually get deployed, making it better for testing. The goal would be to add this as a test step to our release instructions, after merging into `trunk`, running this Action on the `trunk` branch to generate a ZIP that can be downloaded.

\* I don't include WordPress.org assets in this zip, though those will be deployed to WordPress.org

### How to test the Change

Not sure if there's a great way to test this without getting it merged in. I'd be very surprised if this works the first time, I'm expecting maybe some sort of path issue or something similar that will be easier to identify once we can fully test this.

That said, this does copy some of the functionality from our [WordPress.org Plugin Deploy action](https://github.com/10up/action-wordpress-plugin-deploy), including checking out the SVN repo and using that to build the final zip. This ensures we have the most accurate final release to test as possible but I'd be grateful for closer review on the SVN piece just to ensure we won't accidentally commit anything to the SVN repo here (very unlikely as I've removed all those parts but good to have a second set of eyes)

### Changelog Entry

Not applicable

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
