### PR TITLE
Remove extra s from success.

### DIFF
--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -556,7 +556,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 			return new WP_REST_Response(
 				array(
 					'status'        => 200,
-					'response'      => 'successs',
+					'response'      => 'success',
 					'body_response' => $page_ordering,
 				)
 			);


### PR DESCRIPTION
### Description of the Change
Corrects a typo by replacing 'successs' with 'success'.

Closes #132

### How to test the Change
1. Check line [559 of simple-page-ordering.php](https://github.com/10up/simple-page-ordering/pull/133/files)
2. Ensure 'success' has just two instances of 's' (two esses?)

### Changelog Entry
> Removed extra s from success.

### Credits
Props @ruscoe

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
