### PR TITLE
Fix for the "Are you sure..." confirmation message not being translatable

### DIFF
--- a/assets/js/src/simple-page-ordering.js
+++ b/assets/js/src/simple-page-ordering.js
@@ -181,8 +181,15 @@ jQuery(function () {
 	jQuery('#simple-page-ordering-reset').on('click', function (e) {
 		e.preventDefault();
 		const post_type = jQuery(this).data('posttype');
-		// eslint-disable-next-line no-alert
-		if (window.confirm(`Are you sure you want to reset the ${post_type} order?`)) {
+		if (
+			// eslint-disable-next-line no-alert
+			window.confirm(
+				window.simple_page_ordering_localized_data.confirmation_msg.replace(
+					`{post_type}`,
+					post_type,
+				),
+			)
+		) {
 			jQuery.post(
 				window.ajaxurl,
 				{

--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -140,7 +140,8 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 						'simple-page-ordering',
 						'simple_page_ordering_localized_data',
 						array(
-							'_wpnonce' => wp_create_nonce( 'simple-page-ordering-nonce' ),
+							'_wpnonce'         => wp_create_nonce( 'simple-page-ordering-nonce' ),
+							'confirmation_msg' => __( 'Are you sure you want to reset the {post_type} order?', 'simple-page-ordering' )
 						)
 					);
 

--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -141,7 +141,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 						'simple_page_ordering_localized_data',
 						array(
 							'_wpnonce'         => wp_create_nonce( 'simple-page-ordering-nonce' ),
-							'confirmation_msg' => __( 'Are you sure you want to reset the {post_type} order?', 'simple-page-ordering' )
+							'confirmation_msg' => __( 'Are you sure you want to reset the {post_type} order?', 'simple-page-ordering' ),
 						)
 					);
 

--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -141,7 +141,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 						'simple_page_ordering_localized_data',
 						array(
 							'_wpnonce'         => wp_create_nonce( 'simple-page-ordering-nonce' ),
-							'confirmation_msg' => __( 'Are you sure you want to reset the {post_type} order?', 'simple-page-ordering' ),
+							'confirmation_msg' => __( 'Are you sure you want to reset the ordering of the "{post_type}" post type?', 'simple-page-ordering' ),
 						)
 					);
 


### PR DESCRIPTION
### Description of the Change

Fix for the "Are you sure..." confirmation message not being translatable

Closes #143 

### How to test the Change

1. Switch to a different language other than english
2. Go to page list and open Screen options.
3. Click Simple page ordering and press Reset post order.
4. See the translatable message

### Changelog Entry

> Fixed - Fixed the "Are you sure..." popup text to be translatable


### Credits

Props @bmarshall511 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
