### PR TITLE
Fix a few minor code issues

### DIFF
--- a/assets/js/src/simple-page-ordering.js
+++ b/assets/js/src/simple-page-ordering.js
@@ -69,7 +69,6 @@ function update_simple_ordering_callback(response) {
 				nextid: changes.next.nextid,
 				start: changes.next.start,
 				_wpnonce: window.simple_page_ordering_localized_data._wpnonce,
-				screen_id: window.simple_page_ordering_localized_data.screen_id,
 				excluded: JSON.stringify(changes.next.excluded),
 			},
 			update_simple_ordering_callback,
@@ -158,7 +157,6 @@ sortable_post_table.sortable({
 				previd: prevpostid,
 				nextid: nextpostid,
 				_wpnonce: window.simple_page_ordering_localized_data._wpnonce,
-				screen_id: window.simple_page_ordering_localized_data.screen_id,
 			},
 			update_simple_ordering_callback,
 		);
@@ -183,12 +181,7 @@ jQuery(function () {
 		const post_type = jQuery(this).data('posttype');
 		if (
 			// eslint-disable-next-line no-alert
-			window.confirm(
-				window.simple_page_ordering_localized_data.confirmation_msg.replace(
-					`{post_type}`,
-					post_type,
-				),
-			)
+			window.confirm(window.simple_page_ordering_localized_data.confirmation_msg)
 		) {
 			jQuery.post(
 				window.ajaxurl,
@@ -196,7 +189,6 @@ jQuery(function () {
 					action: 'reset_simple_page_ordering',
 					post_type,
 					_wpnonce: window.simple_page_ordering_localized_data._wpnonce,
-					screen_id: window.simple_page_ordering_localized_data.screen_id,
 				},
 				function () {
 					window.location.reload();

--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -122,8 +122,10 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 		 * when we load up our posts query, if we're actually sorting by menu order, initialize sorting scripts
 		 */
 		public static function wp() {
-			$orderby = get_query_var( 'orderby' );
-			$screen  = get_current_screen();
+			$orderby   = get_query_var( 'orderby' );
+			$screen    = get_current_screen();
+			$post_type = $screen->post_type ?? 'post';
+
 			if ( ( is_string( $orderby ) && 0 === strpos( $orderby, 'menu_order' ) ) || ( isset( $orderby['menu_order'] ) && 'ASC' === $orderby['menu_order'] ) ) {
 
 				$script_name       = 'dist/js/simple-page-ordering.js';
@@ -141,7 +143,8 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 						'simple_page_ordering_localized_data',
 						array(
 							'_wpnonce'         => wp_create_nonce( 'simple-page-ordering-nonce' ),
-							'confirmation_msg' => __( 'Are you sure you want to reset the ordering of the "{post_type}" post type?', 'simple-page-ordering' ),
+							/* translators: %1$s is replaced with the post type name */
+							'confirmation_msg' => sprintf( esc_html__( 'Are you sure you want to reset the ordering of the "%1$s" post type?', 'simple-page-ordering' ), $post_type ),
 						)
 					);
 
@@ -165,8 +168,9 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 		 * Add page ordering help to the help tab
 		 */
 		public static function admin_head() {
-			$reset_order = sprintf( '<a href="#" id="simple-page-ordering-reset" data-posttype="%s">%s</a>', get_query_var( 'post_type' ), __( 'Reset post order', 'simple-page-ordering' ) );
-			$screen      = get_current_screen();
+			$screen    = get_current_screen();
+			$post_type = $screen->post_type ?? 'post';
+
 			$screen->add_help_tab(
 				array(
 					'id'      => 'simple_page_ordering_help_tab',
@@ -174,8 +178,9 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 					'content' => sprintf(
 						'<p>%s</p><a href="#" id="simple-page-ordering-reset" data-posttype="%s">%s</a>',
 						esc_html__( 'To reposition an item, simply drag and drop the row by "clicking and holding" it anywhere (outside of the links and form controls) and moving it to its new position.', 'simple-page-ordering' ),
-						get_query_var( 'post_type' ),
-						esc_html__( 'Reset post order', 'simple-page-ordering' )
+						esc_attr( get_query_var( 'post_type' ) ),
+						/* translators: %1$s is replaced with the post type name */
+						sprintf( esc_html__( 'Reset %1$s order', 'simple-page-ordering' ), $post_type )
 					),
 				)
 			);


### PR DESCRIPTION
### Description of the Change

While reviewing #148 I noticed there was some code that was no longer being used. I tracked that down to #129, where we refactored a few things but left some code in place that wasn't actually being used.

While putting together this PR to remove that code, I also noticed we had missing escaping in one place and that a couple of our text strings we show could be translated slightly better, so all of those have been fixed here.

So the things this PR does:

1. Removes the code that references the `screen_id`, as the underlying code was removed in #129 but some code was left in place
2. Update the reset confirmation message to use the post type on the PHP side (instead of replacing that on the JS side) and add a translator comment for that
3. Add the post type to our reset message so it isn't hardcoded to always say `post`
4. Add escaping around the post type value

### How to test the Change

1. Ensure you have a post type that is sortable (like the default `page` post type)
2. Add multiple items within this post type
3. Ensure you can sort these items by drag-and-drop
4. Go to the `Help` tab and click on the `Simple Page Ordering` tab
5. Ensure the reset message shows with the correct post type name
6. Ensure clicking on this link shows a confirmation dialog with a message that reflects the proper post type
7. Confirm this dialog and ensure post type sorting has been reset
 
### Changelog Entry

> Changed - Slightly change how some of our text is translated, passing in the post type
> Fixed - Remove code that was no longer needed
> Fixed - Add missing escaping

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
