### PR TITLE
Add a check to ensure we have a valid PHP version before loading plugin functionality and output an admin notice if needed

### DIFF
--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -15,6 +15,55 @@
  * @package simple-page-ordering
  */
 
+namespace SimplePageOrdering;
+
+/**
+ * Get the minimum version of PHP required by this plugin.
+ *
+ * @since 2.5.2
+ *
+ * @return string Minimum version required.
+ */
+function minimum_php_requirement(): string {
+	return '7.4';
+}
+
+/**
+ * Whether PHP installation meets the minimum requirements
+ *
+ * @since 2.5.2
+ *
+ * @return bool True if meets minimum requirements, false otherwise.
+ */
+function site_meets_php_requirements(): bool {
+	return version_compare( phpversion(), minimum_php_requirement(), '>=' );
+}
+
+// Try to load the plugin files, ensuring our PHP version is met first.
+if ( ! site_meets_php_requirements() ) {
+	add_action(
+		'admin_notices',
+		function() {
+			?>
+			<div class="notice notice-error">
+				<p>
+					<?php
+					echo wp_kses_post(
+						sprintf(
+						/* translators: %s: Minimum required PHP version */
+							__( 'Simple Page Ordering requires PHP version %s or later. Please upgrade PHP or disable the plugin.', 'simple-page-ordering' ),
+							esc_html( minimum_php_requirement() )
+						)
+					);
+					?>
+				</p>
+			</div>
+			<?php
+		}
+	);
+	return;
+}
+
 // Useful global constants.
 define( 'SIMPLE_PAGE_ORDERING_VERSION', '2.5.1' );
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
In this PR, I'm adding a check for the minimum required PHP version before attempting to load the plugin files. If the condition is not met an admin notice is displayed and the plugin files are not loaded.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/simple-page-ordering/issues/150

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
* To see the admin notice and have the plugin functionality not loaded, try to load the plugin on a site with PHP version lower that 7.4.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Check for minimum required PHP version before loading the plugin


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
c