### PR TITLE
I18N issues based on 2.7.0

### DIFF
--- a/class-simple-page-ordering.php
+++ b/class-simple-page-ordering.php
@@ -420,7 +420,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 					esc_url( $move_under_grandparent_link ),
 					sprintf(
 						/* translators: %s: parent page/post title */
-						__( 'Move out from under %s' ),
+						__( 'Move out from under %s', 'simple-page-ordering' ),
 						get_the_title( $parent_id )
 					)
 				);
@@ -455,7 +455,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 					esc_url( $move_under_sibling_link ),
 					sprintf(
 						/* translators: %s: sibling page/post title */
-						__( 'Move under %s' ),
+						__( 'Move under %s', 'simple-page-ordering' ),
 						get_the_title( $sibling )
 					)
 				);


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
If strings in your plugin are also used in WordPress core (e.g., **‘Settings’**), you should still add your own text domain. Otherwise, they’ll become untranslated if the core string changes (which happens). Please refer to [this official article](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#add-text-domain-to-strings).
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
Add the necessary text domain, and replace previous version files, the UI strings with the missing text domain will be applied the translations from language pack (**NOT** from Core)
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - The missing Text Domain


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @alexclassroom


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ x ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ x ] I have updated the documentation accordingly.
- [ x ] I have added tests to cover my change.
- [ x ] All new and existing tests pass.
