### PR TITLE
Update get_walked_pages to support custom post types Closes #200

### DIFF
--- a/class-simple-page-ordering.php
+++ b/class-simple-page-ordering.php
@@ -190,6 +190,8 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 		/**
 		 * Walk the pages and return top level and children pages.
 		 *
+		 * @param string $post_type Post type to walk.
+		 *
 		 * @return array {
 		 *    @type WP_Post[] $top_level_pages Top level pages.
 		 *    @type WP_Post[] $children_pages  Children pages.

--- a/class-simple-page-ordering.php
+++ b/class-simple-page-ordering.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 				wp_die( esc_html__( 'You are not allowed to edit this item.', 'simple-page-ordering' ) );
 			}
 
-			list( 'top_level_pages' => $top_level_pages, 'children_pages' => $children_pages ) = self::get_walked_pages();
+			list( 'top_level_pages' => $top_level_pages, 'children_pages' => $children_pages ) = self::get_walked_pages( $post->post_type );
 
 			// Get the relevant siblings.
 			if ( 0 === $post->post_parent ) {
@@ -195,9 +195,9 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 		 *    @type WP_Post[] $children_pages  Children pages.
 		 * }
 		 */
-		public static function get_walked_pages() {
+		public static function get_walked_pages( $post_type = 'page' ) {
 			global $wpdb;
-			$pages = get_pages( array( 'sort_column' => 'menu_order title' ) );
+			$pages = get_pages( array( 'sort_column' => 'menu_order title', 'post_type' => $post_type ) );
 
 			$top_level_pages = array();
 			$children_pages  = array();
@@ -393,7 +393,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 				return $actions;
 			}
 
-			list( 'top_level_pages' => $top_level_pages, 'children_pages' => $children_pages ) = self::get_walked_pages();
+			list( 'top_level_pages' => $top_level_pages, 'children_pages' => $children_pages ) = self::get_walked_pages( $post->post_type );
 
 			$edit_link                   = get_edit_post_link( $post->ID, 'raw' );
 			$move_under_grandparent_link = add_query_arg(

--- a/class-simple-page-ordering.php
+++ b/class-simple-page-ordering.php
@@ -197,7 +197,12 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 		 */
 		public static function get_walked_pages( $post_type = 'page' ) {
 			global $wpdb;
-			$pages = get_pages( array( 'sort_column' => 'menu_order title', 'post_type' => $post_type ) );
+			$pages = get_pages(
+				array(
+					'sort_column' => 'menu_order title',
+					'post_type'   => $post_type,
+				)
+			);
 
 			$top_level_pages = array();
 			$children_pages  = array();


### PR DESCRIPTION
### Description of the Change
When reordering a custom post type, this `get_walked_pages` call fails with an `undefined array key` error on line 433.
<img width="719" alt="Screenshot 2024-05-09 at 10 10 17 AM" src="https://github.com/10up/simple-page-ordering/assets/8093376/fbca1957-78c5-4ee2-953f-7b5bf4d1523b">

Digging into it more, we can see that the `get_walked_pages` call is outputting only the `top_level_pages` for the `page` post type.
<img width="512" alt="Screenshot 2024-05-09 at 10 16 21 AM" src="https://github.com/10up/simple-page-ordering/assets/8093376/d471a77a-9104-4fae-9453-e4963ee0a6d8">

This is due to the `get_pages` call on line 200 (https://github.com/10up/simple-page-ordering/blob/develop/class-simple-page-ordering.php#L200) defaulting to [`post_type => 'page'`](https://developer.wordpress.org/reference/functions/get_pages/#parameters).

If we tweak this to pass in the `post_type` of the post we're working with, in the same way we do with [`is_post_type_sortable`](https://github.com/10up/simple-page-ordering/blob/develop/class-simple-page-ordering.php#L244), this issue will be resolved.
<img width="608" alt="Screenshot 2024-05-09 at 10 22 48 AM" src="https://github.com/10up/simple-page-ordering/assets/8093376/b7eac041-7f82-491a-950e-a052caf78ce4">

Closes #200

### How to test the Change
- Create a new post type
- Create a parent and child post within this new post type
- Verify debug warning does not get displayed

### Changelog Entry
Fixed error in call to get_walked_pages for custom post types

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @zachgibb


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
