### PR TITLE
Undefined array key error when viewing pages in admin panel

### DIFF
--- a/class-simple-page-ordering.php
+++ b/class-simple-page-ordering.php
@@ -435,10 +435,14 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 
 			// Get the relevant siblings.
 			if ( 0 === $post->post_parent ) {
-				$siblings = $top_level_pages;
-			} else {
-				$siblings = $children_pages[ $post->post_parent ];
-			}
+                $siblings = $top_level_pages;
+            } else {
+                if (isset($children_pages[$post->post_parent])) {
+                    $siblings = $children_pages[$post->post_parent];
+                } else {
+                    $siblings = [];
+                }
+            }
 
 			// Assume no sibling.
 			$sibling = 0;

--- a/class-simple-page-ordering.php
+++ b/class-simple-page-ordering.php
@@ -435,14 +435,10 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 
 			// Get the relevant siblings.
 			if ( 0 === $post->post_parent ) {
-                $siblings = $top_level_pages;
-            } else {
-                if (isset($children_pages[$post->post_parent])) {
-                    $siblings = $children_pages[$post->post_parent];
-                } else {
-                    $siblings = [];
-                }
-            }
+				$siblings = $top_level_pages;
+			} else {
+				$siblings = $children_pages[ $post->post_parent ] ?? [];
+			}
 
 			// Assume no sibling.
 			$sibling = 0;


### PR DESCRIPTION


### Description of the Change
This pull request addresses an "Undefined array key" error that occurs when a post parent ID does not exist in the `$children_pages` array.

Changes Made:

- Added an `isset()` check before accessing the `$children_pages `array with the post parent ID.
- If the key does not exist, `$siblings` is set to an empty array to handle the case gracefully.

Closes #218 

### How to test the Change
Due to me not knowing exactly how this bug happened as it wasnt originally found by me, I can only assume. This bug was originally found by someone who edited a picture on a page and then dragged that page around to be a child page of another, which resulted in the Undefined array key error on the pages panel. 

### Changelog Entry
> Fixed - issue where an `"Undefined array key"` error occurs when a post parent ID does not exist in the `$children_pages` array.


### Credits
Props @xDehy


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
