### PR TITLE
add banner image, tweak badges, tweak copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # Simple Page Ordering
 
+![Simple Page Ordering](https://github.com/10up/simple-page-ordering/blob/develop/.wordpress-org/banner-1544x500.png)
+
+[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/simple-page-ordering?label=WordPress) [![GPLv2 License](https://img.shields.io/github/license/10up/simple-page-ordering.svg)](https://github.com/10up/simple-page-ordering/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/simple-page-ordering/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/simple-page-ordering/actions/workflows/dependency-review.yml) [![WordPress Playground Demo](https://img.shields.io/wordpress/plugin/v/simple-page-ordering?logo=wordpress&logoColor=FFFFFF&label=Playground%20Demo&labelColor=3858E9&color=3858E9)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/10up/simple-page-ordering/add/badges/.wordpress-org/blueprints/blueprint.json)
+
+[![E2E test](https://github.com/10up/simple-page-ordering/actions/workflows/cypress.yml/badge.svg)](https://github.com/10up/simple-page-ordering/actions/workflows/cypress.yml) [![PHP Compatibility](https://github.com/10up/simple-page-ordering/actions/workflows/php-compatibility.yml/badge.svg)](https://github.com/10up/simple-page-ordering/actions/workflows/php-compatibility.yml) [![PHPCS](https://github.com/10up/simple-page-ordering/actions/workflows/phpcs.yml/badge.svg)](https://github.com/10up/simple-page-ordering/actions/workflows/phpcs.yml) [![JS Lint](https://github.com/10up/simple-page-ordering/actions/workflows/jslint.yml/badge.svg)](https://github.com/10up/simple-page-ordering/actions/workflows/jslint.yml) [![CodeQL](https://github.com/10up/simple-page-ordering/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/10up/simple-page-ordering/actions/workflows/github-code-scanning/codeql)
+
 > Order your pages and other hierarchical post types with simple drag and drop right from the standard page list.
 
-[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/simple-page-ordering?label=WordPress) [![GPLv2 License](https://img.shields.io/github/license/10up/simple-page-ordering.svg)](https://github.com/10up/simple-page-ordering/blob/develop/LICENSE.md) [![WordPress Playground Demo](https://img.shields.io/wordpress/plugin/v/simple-page-ordering?logo=wordpress&logoColor=FFFFFF&label=Playground%20Demo&labelColor=3858E9&color=3858E9)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/10up/simple-page-ordering/add/badges/.wordpress-org/blueprints/blueprint.json)
+## Overview
 
-[![E2E test](https://github.com/10up/simple-page-ordering/actions/workflows/cypress.yml/badge.svg)](https://github.com/10up/simple-page-ordering/actions/workflows/cypress.yml) [![PHP Compatibility](https://github.com/10up/simple-page-ordering/actions/workflows/php-compatibility.yml/badge.svg)](https://github.com/10up/simple-page-ordering/actions/workflows/php-compatibility.yml) [![PHPCS](https://github.com/10up/simple-page-ordering/actions/workflows/phpcs.yml/badge.svg)](https://github.com/10up/simple-page-ordering/actions/workflows/phpcs.yml) [![JS Lint](https://github.com/10up/simple-page-ordering/actions/workflows/jslint.yml/badge.svg)](https://github.com/10up/simple-page-ordering/actions/workflows/jslint.yml) [![Dependency Review](https://github.com/10up/simple-page-ordering/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/simple-page-ordering/actions/workflows/dependency-review.yml)
+Order your pages and other custom post types that support "page-attributes" with drag and drop right from the built in page list.
 
-Order your pages and other custom post types that support "page-attributes" with simple drag and drop right from the built in page list.
-
-Simply drag and drop the page into the desired position. It's that simple. No new admin menus pages, no clunky, bolted on user interfaces. Just drag and drop on the page or post-type screen.
+Drag and drop the page into the desired position. No new admin menus pages, no clunky, bolted on user interfaces. Drag and drop on the page or post-type screen.
 
 The plug-in is "capabilities aware" - only users with the ability to edit others' pages (editors and administrators) will be able to reorder content.
 
-Integrated help is included: just click the "help" tab at the top right of the screen.
+Integrated help is included: click the "help" tab at the top right of the screen.
 
 Please note that the plug-in is not compatible with Internet Explorer 7 and earlier, due to limitations within those browsers.
 
@@ -95,6 +99,7 @@ add_filter( 'simple_page_ordering_is_sortable', function( $sortable, $post_type 
 Yes. The plugin registers the REST endpoint `simple-page-ordering/v1/page_ordering`.
 
 #### Input parameters
+
 | Name    | Type    |Description                                                  | Mandatory |  Default value |
 |--------:|--------:|------------------------------------------------------------:|----------:|---------------:|
 | id      | integer | The ID of the post you are positioning                      | yes       |                |
@@ -104,6 +109,7 @@ Yes. The plugin registers the REST endpoint `simple-page-ordering/v1/page_orderi
 | exclude | array   | Array of post IDs to be excluded                            | no        | empty array    |
 
 #### Example request
+
 | Type    | URL                                                                                  |
 |--------:|-------------------------------------------------------------------------------------:|
 | post    | /wp-json/simple-page-ordering/v1/page_ordering/?id=2&previd=13&nextid=14&excluded=[] |

--- a/readme.txt
+++ b/readme.txt
@@ -7,17 +7,17 @@ Stable tag:        2.7.2
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
-Order your pages and other custom post types that support "page-attributes" with simple drag and drop right from the standard page list.
+Order your pages and other custom post types that support "page-attributes" with drag and drop right from the standard page list.
 
 == Description ==
 
-Order your pages, hierarchical custom post types, or custom post types with "page-attributes" with simple drag and drop right from the built in page list.
+Order your pages, hierarchical custom post types, or custom post types with "page-attributes" with drag and drop right from the built in page list.
 
-Simply drag and drop the page into the desired position. It's that simple. No new admin menus pages, no clunky, bolted on user interfaces. Just drag and drop on the page or post-type screen.
+Drag and drop the page into the desired position. No new admin menus pages, no clunky, bolted on user interfaces. Drag and drop on the page or post-type screen.
 
 The plug-in is "capabilities aware" - only users with the ability to edit others' pages (editors and administrators) will be able to reorder content.
 
-Integrated help is included: just click the "help" tab at the top right of the screen.
+Integrated help is included: click the "help" tab at the top right of the screen.
 
 Please note that the plug-in is not compatible with Internet Explorer 7 and earlier, due to limitations within those browsers.
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR adds in the plugin banner image to the readme to give a bit more visual appear to the readme intro to new plugin users/developers. Also updates the badges displayed.  Finally tweaks copy to remove "just" and "simple" references.

### How to test the Change
Preview via the GitHub markdown previewer.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
n/a

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
