### PR TITLE
Issue 205: Resolved issue with emoji in page titles.

### DIFF
--- a/assets/js/src/simple-page-ordering.js
+++ b/assets/js/src/simple-page-ordering.js
@@ -41,6 +41,13 @@ function update_simple_ordering_callback(response) {
 				const dom_post_title = inline_key.querySelector('.post_title');
 				if (dom_post_title !== null) {
 					post_title = dom_post_title.innerHTML;
+
+					// Convert emoji img tags back to Unicode emoji characters
+					// See: https://github.com/10up/simple-page-ordering/issues/205
+					post_title = post_title.replace(
+						/<img[^>]*class="emoji"[^>]*alt="([^"]*)"[^>]*>/g,
+						'$1',
+					);
 				}
 
 				let dashes = 0;
@@ -50,7 +57,7 @@ function update_simple_ordering_callback(response) {
 				}
 				const dom_row_title = inline_key.parentNode.querySelector('.row-title');
 				if (dom_row_title !== null && post_title !== null) {
-					dom_row_title.textContent = decodeEntities(post_title);
+					dom_row_title.innerHTML = decodeEntities(post_title);
 				}
 			} else if (dom_menu_order !== null) {
 				dom_menu_order.textContent = new_pos[key];

--- a/tests/bin/initialize.sh
+++ b/tests/bin/initialize.sh
@@ -11,6 +11,7 @@ wp-env run tests-cli wp post create --post_status=publish --post_title='Post 3'
 wp-env run tests-cli wp post create --post_status=publish --post_type=page  --post_title='Page 1' --menu_order=10
 wp-env run tests-cli wp post create --post_status=publish --post_type=page  --post_title='Page 2' --menu_order=20
 wp-env run tests-cli wp post create --post_status=publish --post_type=page  --post_title='Page 3' --menu_order=30
+wp-env run tests-cli wp post create --post_status=publish --post_type=page  --post_title='Hey there! 👋' --menu_order=15
 wp-env run tests-cli wp post create --post_status=publish --post_type=page --post_parent=6 --post_title='Child Page 1' --menu_order=10
 wp-env run tests-cli wp post create --post_status=publish --post_type=page --post_parent=6 --post_title='Child Page 2' --menu_order=20
 wp-env run tests-cli wp post create --post_status=publish --post_type=page --post_parent=6 --post_title='Child Page 3' --menu_order=30

--- a/tests/cypress/integration/page-ordering.test.js
+++ b/tests/cypress/integration/page-ordering.test.js
@@ -47,6 +47,39 @@ describe('Test Page Order Change', () => {
 		} );
 	});
 
+	it('Can preserve emojis in page titles during reordering', () => {
+		// Find the emoji page that was created during setup
+		cy.contains('.row-title', 'Hey there! 👋').should('exist').as('emojiPage');
+		
+		// Get the parent row of our emoji page
+		cy.get('@emojiPage').parents('tr').as('emojiPageRow');
+		
+		// Store the initial emoji title text
+		cy.get('@emojiPage').invoke('text').as('initialEmojiTitle');
+		
+		// Get the ID of the emoji page row for debugging
+		cy.get('@emojiPageRow').invoke('attr', 'id').then(rowId => {
+			cy.log('Emoji page row ID:', rowId);
+		});
+		
+		// Perform the drag operation to trigger the callback
+		cy.get('@emojiPageRow').drag(secondTopLevelPage);
+		
+		// Wait for the ordering update to complete with a timeout
+		cy.get('.wp-list-table tbody tr .check-column input', { timeout: 10000 }).should('exist');
+		
+		// Add a small wait to ensure the callback has completed
+		cy.wait(1000);
+		
+		// Verify the emoji is still present and unchanged in the title
+		cy.get('@initialEmojiTitle').then(initialTitle => {
+			cy.log('Initial title was:', initialTitle);
+			cy.contains('.row-title', 'Hey there! 👋')
+				.should('exist')
+				.should('have.text', initialTitle);
+		});
+	});
+
 	// Reset page ordering state.
 	after( () => {
 		cy.login();


### PR DESCRIPTION
### Description of the Change
In some cases, the supplied post title is already HTML encoded, added a function to split emoji images to only show the emoji icon, not the HTML reported

Closes #205

### How to test the Change
1. Install the plugin through git clone in the wp-content directory: `git clone git@github.com:10up/simple-page-ordering.git`
2. Checkout the `issue/205-dragging-page-with-emoji-renders-html-in-page-title` branch
3. Install dependencies: `composer install; npm install; npm run build;`
4. In test install, activate plugin
5. Create and publish a page with a title that contains emoji, e.g. "hey there! 👋"
6. Reorder the menu item with the emoji
7. Confirm the emoji remains as an emoji; you do not see HTML content


### Changelog Entry
> Fixed - Resolved issue with emoji showing in page title after reordering

### Credits
Props @jamesmorrison

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
