### PR TITLE
Add filter to disable page row actions

### DIFF
--- a/class-simple-page-ordering.php
+++ b/class-simple-page-ordering.php
@@ -400,6 +400,20 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 				return $actions;
 			}
 
+			/**
+			 * Allow or disallow new row actions.
+			 *
+			 * @since 2.7.5
+			 *
+			 * @param boolean $should_add_actions Whether to add the new row actions.
+			 * @param array   $actions            An array of row action links.
+			 * @param WP_Post $post               The post object.
+			 */
+			$should_add_actions = apply_filters( 'simple_page_ordering_allow_row_actions', true, $actions, $post );
+			if ( ! $should_add_actions ) {
+				return $actions;
+			}
+
 			list( 'top_level_pages' => $top_level_pages, 'children_pages' => $children_pages ) = self::get_walked_pages( $post->post_type );
 
 			$edit_link                   = get_edit_post_link( $post->ID, 'raw' );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR introduces a new filter to disable the page row actions this plugin adds.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #220

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Activate this plugin
2. Add this code into your theme's functions.php file:
```php
add_filter( 'simple_page_ordering_allow_row_actions', '__return_false' );
```
3. Check the pages list in admin, and you should not see the page row actions this plugin is adding.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New filter `simple_page_ordering_allow_row_actions` to disallow the new page row actions.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @sanketio 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
