### PR TITLE
Bump wordpress versions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.6'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.8'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
 
     steps:

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, jakemgold, welcher, helen, thinkoomph, jeffpaul
 Donate link:       http://10up.com/plugins/simple-page-ordering-wordpress/
 Tags:              order, re-order, ordering, page, menu order
-Tested up to:      6.9
+Tested up to:      7.0
 Stable tag:        2.7.4
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -4,7 +4,7 @@
  * Plugin URI:        http://10up.com/plugins/simple-page-ordering-wordpress/
  * Description:       Order your pages and hierarchical post types using drag and drop on the built in page list. For further instructions, open the "Help" tab on the Pages screen.
  * Version:           2.7.4
- * Requires at least: 6.6
+ * Requires at least: 6.8
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Bump WP tested-up-to 7.0 and minimum to 6.8.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #267.

#### Copilot summary

This pull request updates compatibility and requirements for the plugin to support newer WordPress versions. The most important changes are:

**WordPress Version Support:**

* Updated the minimum required WordPress version from 6.6 to 6.8 in the plugin header (`simple-page-ordering.php`).
* Updated the test matrix in the GitHub Actions workflow to use WordPress 6.8 as the minimum version instead of 6.6 (`.github/workflows/cypress.yml`).

**Documentation:**

* Updated the "Tested up to" value in `readme.txt` to indicate compatibility with WordPress 7.0.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - Bump WordPress tested-up-to version 7.0.
> Changed - Bump WordPress minimum supported version to 6.8.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jasperfrontend, @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
