### PR TITLE
Build language files during readme/asset deploy (trunk).

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           npm install
           npm run build
+          npm run makepot
           composer install --no-dev
 
       - name: WordPress.org plugin asset/readme update


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Adds the `npm run makepot` step to the readme/asset deploy action in order to avoid unexpected file differences preventing the deploy of asset updates.

Closes #275 
Follow up to https://github.com/10up/simple-page-ordering/pull/241
Cherry picks https://github.com/10up/simple-page-ordering/pull/276 to trunk

### How to test the Change

Not sure how, to be honest. This is modifying a build action that only runs on GitHub actions.

### Changelog Entry
> Fixed - Workflow to deploy readme and asset updates to wordpress.org

### Credits

Props @peterwilsoncc, @dkotter .

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
