### PR TITLE
Remove bundled translation file in favour of wp.org distributed file.

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -27,7 +27,6 @@ jobs:
         run: |
           npm install
           npm run build
-          npm run makepot
           composer install --no-dev
 
       - name: WordPress.org plugin asset/readme update

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -20,7 +20,6 @@ jobs:
       run: |
         npm install
         npm run build
-        npm run makepot
 
     - name: Install Composer dependencies
       run: composer install --no-dev

--- a/class-simple-page-ordering.php
+++ b/class-simple-page-ordering.php
@@ -49,7 +49,6 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 			add_action( 'load-edit.php', array( __CLASS__, 'load_edit_screen' ) );
 			add_action( 'wp_ajax_simple_page_ordering', array( __CLASS__, 'ajax_simple_page_ordering' ) );
 			add_action( 'wp_ajax_reset_simple_page_ordering', array( __CLASS__, 'ajax_reset_simple_page_ordering' ) );
-			add_action( 'plugins_loaded', array( __CLASS__, 'load_textdomain' ) );
 			add_action( 'rest_api_init', array( __CLASS__, 'rest_api_init' ) );
 
 			// Custom edit page actions.
@@ -238,7 +237,7 @@ if ( ! class_exists( 'Simple_Page_Ordering' ) ) :
 		 * Loads the plugin textdomain
 		 */
 		public static function load_textdomain() {
-			load_plugin_textdomain( 'simple-page-ordering', false, dirname( plugin_basename( __FILE__ ) ) . '/localization/' );
+			_deprecated_function( __METHOD__, '2.8.0' );
 		}
 
 		/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "cypress": "^13.0.0",
         "cypress-mochawesome-reporter": "^3.6.0",
         "mochawesome-json-to-md": "^0.7.2",
-        "node-wp-i18n": "^1.2.7",
         "prettier": "^3.3.2"
       }
     },
@@ -10531,6 +10530,8 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -10540,6 +10541,8 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -12627,31 +12630,6 @@
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/gettext-parser": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-3.1.1.tgz",
-      "integrity": "sha512-vNhWcqXEtZPs5Ft1ReA34g7ByWotpcOIeJvXVy2jF3/G2U9v6W0wG4Z4hXzcU8R//jArqkgHcVCGgGqa4vxVlQ==",
-      "dev": true,
-      "dependencies": {
-        "encoding": "^0.1.12",
-        "readable-stream": "^3.2.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/gettext-parser/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/github-from-package": {
@@ -17762,36 +17740,6 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-wp-i18n": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/node-wp-i18n/-/node-wp-i18n-1.2.7.tgz",
-      "integrity": "sha512-4X+890+Irj8sY+6WKkFx+4wk/GGu9mGLDY1PVPF9AWF1zTKWClLA83QikcQKX55rjjKpN1jSZEQoEANNVSSBYw==",
-      "dev": true,
-      "dependencies": {
-        "bluebird": "^3.4.1",
-        "gettext-parser": "^3.1.0",
-        "glob": "^7.0.5",
-        "lodash": "^4.14.2",
-        "minimist": "^1.2.5",
-        "mkdirp": "^1.0.4",
-        "tmp": "^0.2.1"
-      },
-      "bin": {
-        "wpi18n": "bin/wpi18n"
-      }
-    },
-    "node_modules/node-wp-i18n/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "postenv:start": "./tests/bin/initialize.sh",
     "build": "10up-toolkit build",
     "dev": "10up-toolkit build --watch",
-    "makepot": "wpi18n makepot --domain-path localization --pot-file simple-page-ordering.pot --type plugin --main-file simple-page-ordering.php --exclude bin,dist,node_modules,tests,vendor",
     "format-js": "10up-toolkit format-js",
     "lint-js": "10up-toolkit lint-js"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "cypress": "^13.0.0",
     "cypress-mochawesome-reporter": "^3.6.0",
     "mochawesome-json-to-md": "^0.7.2",
-    "node-wp-i18n": "^1.2.7",
     "prettier": "^3.3.2"
   },
   "scripts": {


### PR DESCRIPTION
### Description of the Change

Removes the bundled translation file, `localization/simple-page-ordering.pot`, in favour of using the version distributed by WordPress.org.

Since WordPress 4.6, plugins hosted on the WordPress Plugin Repository no longer need to include pot files as Core will automatically download the files from the translation repository, see this [make/core post](https://make.wordpress.org/core/2016/07/06/i18n-improvements-in-4-6/).

As a result of this, plugins can remove bundled `.pot` files.

Closes #255 

### How to test the Change

1. Checkout this branch
2. Run `npm ci; npm run build`
3. Delete the `localization` directory in the plugin folder, if required
4. Go to Settings > Genneral
5. Set the language to `Français`
6. Go to the updates page, `/wp-admin/update-core.php`
7. If the `Traductions` section contains a button, click it to update your translations from WP.org
8. Navigate to the pages screen, `/wp-admin/edit.php?post_type=page`
9. In the top navigation ensure that `Sort by Order` is displayed as `Trier par ordre`
10. Return to the General settings page and return the site to your default language to avoid confusion later.

### Changelog Entry
> Changed - Translation .pot file removed in favor of version generated by the WordPress plugin repository.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
