### PR TITLE
Ensure that a tag is in trunk before deploying to WP.org.

### DIFF
--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -16,6 +16,36 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+    - name: Validate tag is on trunk
+      run: |
+        set -euo pipefail
+
+        if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
+          echo "Error: GITHUB_REF does not begin with refs/tags/" >&2
+          exit 1
+        fi
+
+        # For tag pushes, GitHub exposes the tag name in GITHUB_REF_NAME.
+        tag_ref="${GITHUB_REF_NAME}"
+
+        if [[ -z "${tag_ref}" ]]; then
+          echo "Error: GITHUB_REF_NAME is empty." >&2
+          exit 1
+        fi
+
+        if ! tag_commit=$(git rev-parse --verify "${tag_ref}^{commit}" 2>/dev/null); then
+          echo "Error: tag reference '${tag_ref}' does not exist or is not valid." >&2
+          exit 1
+        fi
+
+        # Ensure trunk is available locally, then verify the tag commit is on trunk.
+        git fetch origin trunk
+
+        if ! git merge-base --is-ancestor "${tag_commit}" "origin/trunk"; then
+          echo "Error: tag '${tag_ref}' is not on branch 'trunk'." >&2
+          exit 1
+        fi
+
     - name: Build
       run: |
         npm install


### PR DESCRIPTION

### Description of the Change

When tagging a release, ensure that the tag is on the branch `trunk` before deploying to the WordPress.org plugin repo.

The variables are sourced from the [GitHub Actions Variable Reference](https://docs.github.com/en/actions/reference/workflows-and-actions/variables).

Closes #285 

### How to test the Change

@jeffpaul or @dkotter I don't know how to test this, do you have any ideas?


### Changelog Entry
> Developer - Ensure new tags are on the branch `trunk` before deploying a release to WordPress.org.

### Credits
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
