### PR TITLE
Remove IE7 support docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ The plug-in is "capabilities aware" - only users with the ability to edit others
 
 Integrated help is included: click the "help" tab at the top right of the screen.
 
-Please note that the plug-in is not compatible with Internet Explorer 7 and earlier, due to limitations within those browsers.
-
 Want to help? Check out our [contributing guidelines](CONTRIBUTING.md) to get started.
 
 ## Installation

--- a/readme.txt
+++ b/readme.txt
@@ -19,8 +19,6 @@ The plug-in is "capabilities aware" - only users with the ability to edit others
 
 Integrated help is included: click the "help" tab at the top right of the screen.
 
-Please note that the plug-in is not compatible with Internet Explorer 7 and earlier, due to limitations within those browsers.
-
 === Contributing ===
 
 We'd love to have you join in on development over on [GitHub](https://github.com/10up/simple-page-ordering).


### PR DESCRIPTION
### Description of the Change

Remove Internet Explorer 7 support docs as the browsers referred to are legacy browsers.

Closes #290

### How to test the Change

N/A: Doc only changes.


### Changelog Entry

Not required.

### Credits
Props @peterwilsoncc.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
