### PR TITLE
Version bump script

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -3,6 +3,7 @@
 /.github
 /.wordpress-org
 /assets
+/bin
 /node_modules
 /tests
 /vendor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,8 @@ Head to the Pages list table and drag and drop pages to change the order. Refres
 ### Release instructions
 
 1. Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
-2. Version bump: Bump the version number in `package.json`, `package-lock.json`, `readme.txt`, and `simple-page-ordering.php` if it does not already reflect the version being released. In `class-simple-page-ordering.php` update the plugin `SIMPLE_PAGE_ORDERING_VERSION` constant.
-3. Changelog: Add/update the changelog in `readme.txt` and `CHANGELOG.md`.
+2. Version bump: Run `bin/version-bump.sh <major|minor|patch>` to bump the version number in `package.json`, `package-lock.json`, `readme.txt`, and `simple-page-ordering.php` if it does not already reflect the version being released. In `class-simple-page-ordering.php` update the plugin `SIMPLE_PAGE_ORDERING_VERSION` constant.
+3. Changelog: Populate the changelog entries in `readme.txt` and `CHANGELOG.md` with the log and to include the date of release.
 4. Props: update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
 5. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.distignore`.
 6. Readme updates: Make any other readme changes as necessary. `README.md` is geared toward GitHub and `readme.txt` contains WordPress.org-specific content. The two are slightly different.

--- a/bin/version-bump.sh
+++ b/bin/version-bump.sh
@@ -50,6 +50,11 @@ if grep -Eq "^## \[$next_version\]" CHANGELOG.md; then
 	exit 1
 fi
 
+if grep -Eq "^\[$next_version\]: https://github.com/10up/simple-page-ordering/compare/" CHANGELOG.md; then
+	echo "Changelog footer already contains version $next_version" >&2
+	exit 1
+fi
+
 if grep -Eq "^= $next_version( - .*)? =$" readme.txt; then
 	echo "readme.txt changelog already contains version $next_version" >&2
 	exit 1
@@ -118,5 +123,7 @@ perl -0pi -e "s/^(define\( 'SIMPLE_PAGE_ORDERING_VERSION', ')([^']+)('\s*\);)
 /\${1}$new_version\${3}\n/m" class-simple-page-ordering.php
 
 perl -0pi -e "s/^(## \[Unreleased\].*\n\n)/\${1}## [$new_version] - TBD\n\n/m" CHANGELOG.md
+
+perl -0pi -e "s#^(\[Unreleased\]: .*\n)#\${1}[$new_version]: https://github.com/10up/simple-page-ordering/compare/$current_version...$new_version\n#m" CHANGELOG.md
 
 echo "Bumped version to $new_version"

--- a/bin/version-bump.sh
+++ b/bin/version-bump.sh
@@ -55,6 +55,11 @@ if grep -Eq "^= $next_version( - .*)? =$" readme.txt; then
 	exit 1
 fi
 
+if ! grep -Fq "[View historical changelog details here]" readme.txt; then
+	echo "Unable to find historical changelog link in readme.txt" >&2
+	exit 1
+fi
+
 npm version "$bump_type" --no-git-tag-version >/dev/null
 
 new_version="$(node -p "require('./package.json').version")"
@@ -68,6 +73,43 @@ perl -0pi -e "s/^(Stable tag:\s+).*
 /\${1}$new_version\n/m" readme.txt
 
 perl -0pi -e "s/^(== Changelog ==\r?\n\r?\n)/\${1}= $new_version - TBD =\n\n/m" readme.txt
+
+readme_tmp="$(mktemp)"
+awk '
+	BEGIN {
+		in_changelog = 0
+		release_count = 0
+		skipping_old = 0
+	}
+	/^== Changelog ==\r?$/ {
+		in_changelog = 1
+		print
+		next
+	}
+	in_changelog && /^\[View historical changelog details here\]/ {
+		skipping_old = 0
+		in_changelog = 0
+		print
+		next
+	}
+	in_changelog {
+		if ( $0 ~ /^= [0-9]+\.[0-9]+\.[0-9]+( - .*)? =\r?$/ ) {
+			release_count++
+			if ( release_count > 4 ) {
+				skipping_old = 1
+				next
+			}
+			skipping_old = 0
+		}
+		if ( skipping_old ) {
+			next
+		}
+	}
+	{
+		print
+	}
+' readme.txt > "$readme_tmp"
+mv "$readme_tmp" readme.txt
 
 perl -0pi -e "s/^(\s*\* Version:\s+).*
 /\${1}$new_version\n/m" simple-page-ordering.php

--- a/bin/version-bump.sh
+++ b/bin/version-bump.sh
@@ -2,6 +2,21 @@
 
 set -euo pipefail
 
+required_commands=(awk dirname grep mktemp mv node npm perl)
+missing_commands=()
+
+for required_command in "${required_commands[@]}"; do
+	if ! command -v "$required_command" >/dev/null 2>&1; then
+		missing_commands+=("$required_command")
+	fi
+done
+
+if (( ${#missing_commands[@]} > 0 )); then
+	echo "Missing required command(s): ${missing_commands[*]}" >&2
+	echo "Please install the missing command(s) and try again." >&2
+	exit 1
+fi
+
 if [[ $# -ne 1 ]]; then
 	echo "Usage: $0 <major|minor|patch>" >&2
 	exit 1

--- a/bin/version-bump.sh
+++ b/bin/version-bump.sh
@@ -50,6 +50,11 @@ if grep -Eq "^## \[$next_version\]" CHANGELOG.md; then
 	exit 1
 fi
 
+if grep -Eq "^= $next_version( - .*)? =$" readme.txt; then
+	echo "readme.txt changelog already contains version $next_version" >&2
+	exit 1
+fi
+
 npm version "$bump_type" --no-git-tag-version >/dev/null
 
 new_version="$(node -p "require('./package.json').version")"
@@ -61,6 +66,8 @@ fi
 
 perl -0pi -e "s/^(Stable tag:\s+).*
 /\${1}$new_version\n/m" readme.txt
+
+perl -0pi -e "s/^(== Changelog ==\r?\n\r?\n)/\${1}= $new_version - TBD =\n\n/m" readme.txt
 
 perl -0pi -e "s/^(\s*\* Version:\s+).*
 /\${1}$new_version\n/m" simple-page-ordering.php

--- a/bin/version-bump.sh
+++ b/bin/version-bump.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+	echo "Usage: $0 <major|minor|patch>" >&2
+	exit 1
+fi
+
+bump_type="$1"
+
+case "$bump_type" in
+	major|minor|patch)
+		;;
+	*)
+		echo "Invalid bump type: $bump_type" >&2
+		echo "Expected one of: major, minor, patch" >&2
+		exit 1
+		;;
+esac
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_dir="$(cd "$script_dir/.." && pwd)"
+
+cd "$repo_dir"
+
+for required_file in readme.txt simple-page-ordering.php class-simple-page-ordering.php package.json package-lock.json CHANGELOG.md; do
+	if [[ ! -f "$required_file" ]]; then
+		echo "Missing required file: $required_file" >&2
+		exit 1
+	fi
+done
+
+current_version="$(node -p "require('./package.json').version")"
+
+if [[ -z "$current_version" ]]; then
+	echo "Unable to determine current version from package.json" >&2
+	exit 1
+fi
+
+next_version="$(node -e "const [major, minor, patch] = require('./package.json').version.split('.').map(Number); const bump = process.argv[1]; const next = { major: [major + 1, 0, 0], minor: [major, minor + 1, 0], patch: [major, minor, patch + 1] }[bump]; if (!next || next.some(Number.isNaN)) { process.exit(1); } process.stdout.write(next.join('.'));" "$bump_type")"
+
+if [[ -z "$next_version" ]]; then
+	echo "Unable to calculate next version" >&2
+	exit 1
+fi
+
+if grep -Eq "^## \[$next_version\]" CHANGELOG.md; then
+	echo "Changelog already contains version $next_version" >&2
+	exit 1
+fi
+
+npm version "$bump_type" --no-git-tag-version >/dev/null
+
+new_version="$(node -p "require('./package.json').version")"
+
+if [[ -z "$new_version" ]]; then
+	echo "Unable to determine updated version from package.json" >&2
+	exit 1
+fi
+
+perl -0pi -e "s/^(Stable tag:\s+).*
+/\${1}$new_version\n/m" readme.txt
+
+perl -0pi -e "s/^(\s*\* Version:\s+).*
+/\${1}$new_version\n/m" simple-page-ordering.php
+
+perl -0pi -e "s/^(define\( 'SIMPLE_PAGE_ORDERING_VERSION', ')([^']+)('\s*\);)
+/\${1}$new_version\${3}\n/m" class-simple-page-ordering.php
+
+perl -0pi -e "s/^(## \[Unreleased\].*\n\n)/\${1}## [$new_version] - TBD\n\n/m" CHANGELOG.md
+
+echo "Bumped version to $new_version"

--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 Contributors:      10up, jakemgold, welcher, helen, thinkoomph, jeffpaul
 Donate link:       http://10up.com/plugins/simple-page-ordering-wordpress/
 Tags:              order, re-order, ordering, page, menu order
+Requires at least: 6.8
 Tested up to:      7.0
 Stable tag:        2.8.0
 License:           GPLv2 or later

--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -4,7 +4,6 @@
  * Plugin URI:        http://10up.com/plugins/simple-page-ordering-wordpress/
  * Description:       Order your pages and hierarchical post types using drag and drop on the built in page list. For further instructions, open the "Help" tab on the Pages screen.
  * Version:           2.8.0
- * Requires at least: 6.8
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com


### PR DESCRIPTION
### Description of the Change

Introduces a version bump script to make doing so easier. The script does the following:

* bumps the version in the NPM config files: `package(-lock)?.json`
* bumps the stable tag in `readme.txt`
* bumps the version in the main plugin file
* bumps the version constant in the main class file
* Adds an empty changelog entry to `CHANGELOG.md` with the associated link.
* Adds an empty changelog entry to `readme.txt`
* Removes all but the last four changelog entries from `readme.txt` to ensure the file is below wordpress.org size limits

Closes #293

#### Use of AI

Model: `GPT-5.3-Codex • 7.7`

### How to test the Change

1. Run `bin/version-bump.sh patch` 
2. Ensure the version number is bumped by 0.0.1
3. Ensure the old version number no longer appears as the current version anywhere - it should be removed in most places except the change logs
4. Review the PHP changes to ensure there are no syntax errors.

### Changelog Entry
> Developer - Introduce version bump script.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
